### PR TITLE
Only import ContractEvent when the contract has events

### DIFF
--- a/src/generation.ts
+++ b/src/generation.ts
@@ -17,7 +17,7 @@ export function codegen(contract: Contract, abi: RawAbiDefinition[]) {
   import { AbiItem, Callback, CeloTxObject, Contract, EventLog } from '@celo/connect'
   import { EventEmitter } from 'events'
   import Web3 from 'web3'
-  import { ContractEvent, EventOptions } from './types'
+  import {${ contract.events.length ? 'ContractEvent,' : '' } EventOptions } from './types'
 
   export interface ${contract.name} extends Contract {
     clone(): ${contract.name}

--- a/src/generation.ts
+++ b/src/generation.ts
@@ -17,7 +17,7 @@ export function codegen(contract: Contract, abi: RawAbiDefinition[]) {
   import { AbiItem, Callback, CeloTxObject, Contract, EventLog } from '@celo/connect'
   import { EventEmitter } from 'events'
   import Web3 from 'web3'
-  import {${ contract.events.length ? 'ContractEvent,' : '' } EventOptions } from './types'
+  import {${ values(contract.events).length ? 'ContractEvent,' : '' } EventOptions } from './types'
 
   export interface ${contract.name} extends Contract {
     clone(): ${contract.name}


### PR DESCRIPTION
In my work to add cEUR support to contractkit, I'm making some changes to include a wrapper for tokens that implement the `IERC20` and `ICeloToken` interfaces. For this, I needed to generate a typescript file for each interface, and I encountered an issue where TS files that were generated for contracts/interfaces that do not have any events would import `ContractEvent` without actually needing it.

I tested this by locally changing monorepo to pull this package from my own branch, and all worked smoothly